### PR TITLE
Make lisp lint happier.

### DIFF
--- a/cperl-mode.el
+++ b/cperl-mode.el
@@ -1490,8 +1490,7 @@ does not need a semicolon to terminate the statement.")
     "field"
     (1+ ,cperl--ws-or-comment-rx)
     ,cperl--basic-variable-rx
-    (optional (sequence ,cperl--ws+-rx ,cperl--attribute-list-rx))
-    )
+    (optional (sequence ,cperl--ws+-rx ,cperl--attribute-list-rx)))
   "A regular expression to find a declaration for a field.
 Fields can have attributes for fontification, and even for imenu because
 for example \":reader\" implicitly declares a method.")
@@ -2261,8 +2260,7 @@ Argument ARG is the closing parenthesis."
     (if (and other-end
 	     (cperl-val 'cperl-electric-parens)
 	     (memq last-command-event '( ?\) ?\] ?\} ?\> ))
-	     (>= (save-excursion (cperl-to-comment-or-eol) (point)) (point))
-	     )
+	     (>= (save-excursion (cperl-to-comment-or-eol) (point)) (point)))
 	(progn
 	  (self-insert-command (prefix-numeric-value arg))
 	  (setq p (point))
@@ -4057,8 +4055,7 @@ an attribute.  ST-L and POS are a cached from a previous call."
       ;; be included into the area marked as sub-decl.
       nil)
      ;; Else, we are in no mans land.  Just keep trying.
-     (t
-      ))
+     (t))
     (when (looking-at (rx (in ";{")))
       ;; A semicolon ends the declaration, an opening brace begins the
       ;; BLOCK.  Neither is part of the declaration.
@@ -4117,8 +4114,7 @@ and character escapes, respectively."
 	  "\\|"
 	  "\\("				; 7: other escapes
 	    "\\\\[pP]" "\\([^{]\\|{[^{}]*}\\)"
-	    "\\|" "\\\\[^pP]" "\\)"
-	  )
+	    "\\|" "\\\\[^pP]" "\\)")
 	 endbracket 'toend)
       (if (match-beginning 4)
 	  (cperl-postpone-fontification
@@ -4248,8 +4244,7 @@ This is part of `cperl-find-pods-heres' (below)."
                                    'syntax-type 'here-doc)
                 (put-text-property (1- defs-eol) defs-eol
                                    'syntax-table
-                                   (string-to-syntax "< c"))
-                )
+                                   (string-to-syntax "< c")))
             ;; line ends with a "regular" comment: make
             ;; the last character of the comment closing
             ;; it so that we can use the line feed to
@@ -6560,9 +6555,7 @@ functions (which they are not).  Inherits from `default'.")
                     (in "$@%*")
                     (or
                      (eval cperl--normal-identifier-rx)
-                     (eval cperl--special-identifier-rx))
-                    )
-                   )
+                     (eval cperl--special-identifier-rx))))
               ;; (concat "\\<\\(state\\|my\\|local\\|our\\)"
 	      ;;          cperl-maybe-white-and-comment-rex
 	      ;;          "\\(("
@@ -6578,10 +6571,7 @@ functions (which they are not).  Inherits from `default'.")
                                (in "$@%*")
                                (or
                                 (eval cperl--normal-identifier-rx)
-                                (eval cperl--special-identifier-rx))
-                               )
-                              )
-                    )
+                                (eval cperl--special-identifier-rx)))))
                ;; ,(concat "\\="
 	       ;;  	cperl-maybe-white-and-comment-rex
 	       ;;  	","


### PR DESCRIPTION
These are the errors I got, which I fixed with this PR against the upstream brach:

```
File            Line Col Level    ID Message(checker)
 cperl-mode.el  1494   5 warning     Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 cperl-mode.el  2265   7 warning     Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 cperl-mode.el  4061   7 warning     Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 cperl-mode.el  4121   4 warning     Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 cperl-mode.el  4252  17 warning     Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 cperl-mode.el  6564  21 warning     Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 cperl-mode.el  6565  20 warning     Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 cperl-mode.el  6582  32 warning     Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 cperl-mode.el  6583  31 warning     Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 cperl-mode.el  6584  21 warning     Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
```

These issues still remain. Not sure how much change to inflict to correct them:

```
File            Line Col Level    ID Message(checker)
 cperl-mode.el     1   1 warning     "Version:" or "Package-Version:" header is missing. MELPA will handle this, but other archives will not. (emacs-lisp-package)
 cperl-mode.el     1   1 warning     Including "Emacs" in the package summary is usually redundant. (emacs-lisp-package)
 cperl-mode.el     1   1 error       Package should have a Homepage or URL header. (emacs-lisp-package)
 cperl-mode.el  6289   4 warning     `eval-after-load' is for use in configurations, and should rarely be used in packages. (emacs-lisp-package)
 cperl-mode.el  6759   4 warning     `eval-after-load' is for use in configurations, and should rarely be used in packages. (emacs-lisp-package)
